### PR TITLE
Sensor device change. Cross-compiling on arm6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	go build cmd/main.go
 
 armh:
-	GOOS=linux GOARCH=arm go build -o meerkat cmd/main.go
+	GOARM=6 GOOS=linux GOARCH=arm go build -o meerkat cmd/main.go
 
 test:
 	go test -v ./... -args --public-ip=$$(curl api.ipify.org)

--- a/feed/temperature.go
+++ b/feed/temperature.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	sensorDevicePath                      = "/sys/bus/w1/devices/28-3c01d607ca0a/w1_slave"
+	sensorDevicePath                      = "/sys/bus/w1/devices/28-3c01d607cfc6/w1_slave"
 	sensorDevicePathKey                   = "device-path"
 	sensorMinReadingIntervalPathKey       = "min-read"
 	errTemp                         int32 = -1000


### PR DESCRIPTION
1. Replaced physic sensor and changed device path
2. Added explicit arm=6 instruction for cross-compiling on go 1.21.5